### PR TITLE
Fix: minikube fails to start sometimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,9 @@ RUN chmod a+rx /usr/local/bin/minikube && \
     chmod a+rx /usr/local/bin/kubectl && \
     chmod a+rx /start.sh && \
     minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} && \
+    minikube stop && \
+    ls -lR /root/.minikube/cache && \
+    rm -rf /var/lib/localkube/{etcd,certs,kubeconfig} /tmp/* && \
     (cd /root/.minikube && rm -rf $(ls | egrep -v '^cache'))
 
 # Start up docker and then pass any "docker run" args to minikube start


### PR DESCRIPTION
Some builds of minikube-dind fail to start, showing the message:
  Etcd took too long to start
in the localkube.err log. The problem is a timing issue in the docker
build process. During build, if localkube runs long enough to start
etcd, it leaves files in /var/lib/localkube/etcd. If those files are
present in the final minikube-dind image, etcd will not start. Once
removed, etcd will start successfully.

The fix is to remove any race in the build process by ensuring minikube
(and localkube) are stopped, then remove the etcd data directory.

In addition, we now also remove the initial localkube certs and
kubeconfig generated during build, any files in /tmp, and show the
minikube cache during build so it's available in the build log.